### PR TITLE
Add ban/unban system

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1321,6 +1321,8 @@ p {
     border-top-right-radius: 8px;
     border-bottom-right-radius: 8px;
     text-align: right;
+    width: 1%;
+    white-space: nowrap;
 }
 
 .user-table td {
@@ -1345,15 +1347,14 @@ p {
 /* Status indicators */
 .user-table td:nth-child(2) {
     font-weight: 500;
+    width: 1%;
+    white-space: nowrap;
 }
 
 .user-table tbody tr td:nth-child(2) {
     position: relative;
     text-align: right;
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    padding: 6px 16px;
+    vertical-align: middle;
 }
 
 /* Action buttons */

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -27,6 +27,9 @@ router.get('/login', (req, res) => {
         // console.log('Token data:', tokenData);
 //console.log('User permission:', req.session.permission);
         
+        // Update permission level on every login so it's available for ban checks
+        db.run("UPDATE users SET permission = ? WHERE id = ?", [tokenData.permissions || 2, tokenData.id]);
+
         db.run("INSERT INTO users (id, displayName, pin) VALUES (?, ?, ?)", [tokenData.id, tokenData.displayName, null], (err) => {
             // if the table doesnt exist, create it
             if (err && err.message.includes('no such table')) {

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -72,7 +72,7 @@ router.get('/api/leaderboard', async (req, res) => {
     try {
         const db = require('../utils/database');
         const leaderboardData = await new Promise((resolve, reject) => {
-            db.all("SELECT displayName, COALESCE(songsPlayed, 0) as songsPlayed FROM users WHERE id != 4 ORDER BY songsPlayed DESC", (err, rows) => {
+            db.all("SELECT displayName, COALESCE(songsPlayed, 0) as songsPlayed, COALESCE(isBanned, 0) as isBanned FROM users WHERE id != 4 ORDER BY songsPlayed DESC", (err, rows) => {
                 if (err) {
                     return reject(err);
                 }

--- a/routes/spotify.js
+++ b/routes/spotify.js
@@ -406,6 +406,17 @@ router.post('/addToQueue', async (req, res) => {
         }
     }
 
+    // For non-admin users, check if banned
+    const userBanned = await new Promise((resolve, reject) => {
+        db.get("SELECT COALESCE(isBanned, 0) as isBanned FROM users WHERE id = ?", [req.session.token.id], (err, row) => {
+            if (err) reject(err);
+            else resolve(row && row.isBanned === 1);
+        });
+    });
+    if (userBanned) {
+        return res.status(403).json({ ok: false, error: 'You have been banned from using Jukebar. Contact your teacher.' });
+    }
+
     // For non-admin users, check payment
     if (!req.session.hasPaid) {
         //console.log('addToQueue - Payment required. User ID:', req.session.token.id, 'hasPaid:', req.session.hasPaid);
@@ -640,6 +651,17 @@ router.post('/skip', async (req, res) => {
             }
             return res.status(500).json({ ok: false, error: 'Failed to skip', details: error.message });
         }
+    }
+
+    // For non-admin users, check if banned
+    const skipUserBanned = await new Promise((resolve, reject) => {
+        db.get("SELECT COALESCE(isBanned, 0) as isBanned FROM users WHERE id = ?", [req.session.token.id], (err, row) => {
+            if (err) reject(err);
+            else resolve(row && row.isBanned === 1);
+        });
+    });
+    if (skipUserBanned) {
+        return res.status(403).json({ ok: false, error: 'You have been banned from using Jukebar. Contact your teacher.' });
     }
 
     // For non-admin users, check payment and claim it
@@ -893,6 +915,19 @@ router.post('/purchaseShield', isAuthenticated, async (req, res) => {
     // Owner bypass - they can add shields for free
     const userIsOwner = isOwner(userId);
     console.log('Is owner:', userIsOwner, '(userId:', userId, ')');
+
+    // Check if user is banned (non-owners only)
+    if (!userIsOwner) {
+        const shieldUserBanned = await new Promise((resolve, reject) => {
+            db.get("SELECT COALESCE(isBanned, 0) as isBanned FROM users WHERE id = ?", [userId], (err, row) => {
+                if (err) reject(err);
+                else resolve(row && row.isBanned === 1);
+            });
+        });
+        if (shieldUserBanned) {
+            return res.status(403).json({ ok: false, error: 'You have been banned from using Jukebar. Contact your teacher.' });
+        }
+    }
 
     // Check payment FIRST before touching anything else
     if (!userIsOwner) {

--- a/utils/database.js
+++ b/utils/database.js
@@ -24,6 +24,34 @@ db.run(`CREATE TABLE IF NOT EXISTS users (
     songsPlayed INTEGER DEFAULT 0
 );`);
 
+// Migrate: add isBanned column if it doesn't exist
+db.all("PRAGMA table_info(users)", (err, columns) => {
+    if (err) {
+        console.error('Error checking users schema:', err);
+        return;
+    }
+    const hasIsBanned = columns && columns.some(c => c.name === 'isBanned');
+    if (!hasIsBanned) {
+        db.run("ALTER TABLE users ADD COLUMN isBanned INTEGER DEFAULT 0", (alterErr) => {
+            if (alterErr) {
+                console.error('Error adding isBanned column:', alterErr);
+            } else {
+                console.log('Added isBanned column to users table');
+            }
+        });
+    }
+    const hasPermission = columns && columns.some(c => c.name === 'permission');
+    if (!hasPermission) {
+        db.run("ALTER TABLE users ADD COLUMN permission INTEGER DEFAULT 2", (alterErr) => {
+            if (alterErr) {
+                console.error('Error adding permission column:', alterErr);
+            } else {
+                console.log('Added permission column to users table');
+            }
+        });
+    }
+});
+
 db.run(`CREATE TABLE IF NOT EXISTS transactions (
     id INTEGER PRIMARY KEY,
     user_id INTEGER NOT NULL,

--- a/views/leaderboard.ejs
+++ b/views/leaderboard.ejs
@@ -39,12 +39,14 @@
                     else if (rank === 2) rankClass = 'second';
                     else if (rank === 3) rankClass = 'third';
                     
+                    const bannedBadge = user.isBanned ? '<span style="color:#ff4444;font-size:0.75em;font-weight:600;margin-left:6px;">😂 BANNED LOL 😂</span>' : '';
+
                     const item = document.createElement('div');
                     item.className = 'leaderboard-item';
                     item.innerHTML = `
                         <div class="rank ${rankClass}">#${rank}</div>
                         <div class="user-info">
-                            <div class="user-name">${user.displayName}</div>
+                            <div class="user-name">${user.displayName}${bannedBadge}</div>
                         </div>
                         `;
                         if (user.songsPlayed === 1) {

--- a/views/partials/songMenu.ejs
+++ b/views/partials/songMenu.ejs
@@ -89,6 +89,13 @@ document.getElementById('contextBanBtn').addEventListener('click', function() {
         Notify('No track selected!');
         return;
     }
+
+    // Check if user is banned
+    if (typeof userIsBanned !== 'undefined' && userIsBanned) {
+        Notify('You have been banned from Jukebar. Contact your teacher.', 'error');
+        dropdown.style.display = 'none';
+        return;
+    }
     
     // Get track details from the last updateSongMenu event
     const trackData = dropdown.dataset;

--- a/views/player.ejs
+++ b/views/player.ejs
@@ -169,6 +169,55 @@
                     'use strict';
 
                     let useJukebar = true;
+                    let userIsBanned = false;
+
+                    // Check if user is banned on page load
+                    async function checkBanStatus() {
+                        try {
+                            const res = await fetch('/api/me/banned', { headers: { 'Accept': 'application/json' } });
+                            if (res.ok) {
+                                const data = await res.json();
+                                if (data.banned) {
+                                    userIsBanned = true;
+                                    showBanBanner();
+                                }
+                            }
+                        } catch (err) {
+                            console.error('Error checking ban status:', err);
+                        }
+                    }
+
+                    function showBanBanner() {
+                        // Remove existing banner if any
+                        const existing = document.getElementById('ban-banner');
+                        if (existing) existing.remove();
+
+                        const banner = document.createElement('div');
+                        banner.id = 'ban-banner';
+                        banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;z-index:10000;background:#ff4444;color:#fff;text-align:center;padding:12px 16px;font-weight:600;font-size:1rem;box-shadow:0 -2px 8px rgba(0,0,0,0.3);';
+                        banner.textContent = '🚫 You have been banned from Jukebar. LOL COULD NOT BE ME AHAHAHAHAHAH';
+                        document.body.appendChild(banner);
+                    }
+
+                    checkBanStatus();
+
+                    // Real-time ban/unban via WebSocket
+                    socket.on('userBanned', (data) => {
+                        if (data.userId == currentID) {
+                            userIsBanned = true;
+                            showBanBanner();
+                            Notify('You have been banned from Jukebar by your teacher.', 'error');
+                        }
+                    });
+
+                    socket.on('userUnbanned', (data) => {
+                        if (data.userId == currentID) {
+                            userIsBanned = false;
+                            const banner = document.getElementById('ban-banner');
+                            if (banner) banner.remove();
+                            Notify('You have been unbanned! You can use Jukebar again.', 'success');
+                        }
+                    });
 
                     socket.on('auxiliaryPermission', (permission) => {
                         if (permission <= userPermission) {
@@ -192,6 +241,12 @@
                     }
 
                     async function checkPaymentAndPlay(uri) {
+                        // Check if user is banned
+                        if (userIsBanned) {
+                            Notify('You have been banned from Jukebar. Contact your teacher.', 'error');
+                            return;
+                        }
+
                         // Check if Jukebar is enabled
                         if (!useJukebar) {
                             Notify('Jukebar is currently disabled by your teacher.', 'error');
@@ -218,6 +273,12 @@
 
                     async function checkPaymentAndSkip() {
                         console.log('⏭️ Skip clicked - currentlyPlayingUri:', currentlyPlayingUri);
+
+                        // Check if user is banned
+                        if (userIsBanned) {
+                            Notify('You have been banned from Jukebar. Contact your teacher.', 'error');
+                            return;
+                        }
 
                         // Check if Jukebar is enabled
                         if (!useJukebar) {
@@ -538,6 +599,12 @@
                             const uri = button.dataset.uri;
                             const name = button.dataset.name;
                             const artist = button.dataset.artist;
+
+                            // Check if user is banned
+                            if (userIsBanned) {
+                                Notify('You have been banned from Jukebar. Contact your teacher.', 'error');
+                                return;
+                            }
                             
                             // Check if user is owner (owners can start votes for free)
                             const userIsOwner = isOwnerClient(currentID);
@@ -577,6 +644,11 @@
                     };
 
                     window.purchaseShield = function (trackUri, addedAt) {
+                        if (userIsBanned) {
+                            Notify('You have been banned from Jukebar. Contact your teacher.', 'error');
+                            return;
+                        }
+
                         if (!useJukebar) {
                             Notify('Jukebar is currently disabled by your teacher.', 'error');
                             return;

--- a/views/teacher.ejs
+++ b/views/teacher.ejs
@@ -88,6 +88,8 @@
         </div>
 </body>
 <script>
+    const ownerIDs = <%- JSON.stringify(ownerIDs) %>;
+
     function showNotification(message, type = 'info') {
         console.log('showNotification called:', message, type);
         const notification = document.createElement('div');
@@ -145,16 +147,32 @@
 
             users.forEach(user => {
                 const tr = document.createElement('tr');
+                const isBanned = !!(user.isBanned);
+                const isTeacherOrOwner = (user.permission >= 4) || ownerIDs.includes(user.id);
 
                 const nameTd = document.createElement('td');
-                nameTd.textContent = user.displayName || user.username || '';
+                const displayName = user.displayName || user.username || '';
+                let nameHtml = `<span>${displayName}</span>`;
+                if (isBanned) {
+                    nameHtml += '<span style="color:#ff4444;font-size:0.8em;font-weight:600;margin-left:4px;">BANNED</span>';
+                }
+                if (isTeacherOrOwner) {
+                    nameHtml += '<span style="color:#1db954;font-size:0.8em;font-weight:600;margin-left:4px;">TEACHER</span>';
+                }
+                nameTd.innerHTML = nameHtml;
 
                 const actionsTd = document.createElement('td');
-                const btn = document.createElement('button');
-                btn.innerHTML = '<img src="/img/search.png" alt="Transactions">';
-                btn.title = 'View Transactions';
-                btn.className = 'jp-icon-btn';
-                btn.addEventListener('click', async () => {
+
+                // Wrap action buttons in a flex container inside the td
+                const actionsWrapper = document.createElement('div');
+                actionsWrapper.style.cssText = 'display:flex;gap:6px;align-items:center;justify-content:flex-end;';
+
+                // Transactions button
+                const txnBtn = document.createElement('button');
+                txnBtn.innerHTML = '<img src="/img/search.png" alt="Transactions">';
+                txnBtn.title = 'View Transactions';
+                txnBtn.className = 'jp-icon-btn';
+                txnBtn.addEventListener('click', async () => {
                     try {
                         await showUserTransactions(user.displayName);
                     } catch (err) {
@@ -163,7 +181,49 @@
                     }
                 });
 
-                actionsTd.appendChild(btn);
+                // Ban/Unban button
+                const banBtn = document.createElement('button');
+                banBtn.textContent = isBanned ? 'Unban' : 'Ban';
+                banBtn.className = isBanned ? 'unban-button user-ban-btn' : 'ban-button user-ban-btn';
+                banBtn.style.cssText = 'padding:4px 12px;font-size:0.85em;border-radius:6px;cursor:pointer;border:none;font-weight:600;';
+                if (isBanned) {
+                    banBtn.style.background = '#1db954';
+                    banBtn.style.color = '#fff';
+                } else {
+                    banBtn.style.background = '#ff4444';
+                    banBtn.style.color = '#fff';
+                }
+                banBtn.addEventListener('click', async () => {
+                    const action = isBanned ? 'unban' : 'ban';
+                    const confirmMsg = isBanned
+                        ? `Unban ${user.displayName}? They will be able to use Jukebar again.`
+                        : `Ban ${user.displayName}? They will not be able to queue songs, skip, or start ban votes.`;
+                    if (!confirm(confirmMsg)) return;
+
+                    try {
+                        const r = await fetch(`/api/users/${action}`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ username: user.displayName })
+                        });
+                        const data = await r.json();
+                        if (r.ok && (data.success || data.ok)) {
+                            showNotification(`${user.displayName} has been ${action === 'ban' ? 'banned' : 'unbanned'}`, 'success');
+                            fetchUsers(); // Refresh the list
+                        } else {
+                            showNotification(data.error || `Failed to ${action} user`, 'error');
+                        }
+                    } catch (err) {
+                        console.error(`Error ${action}ning user:`, err);
+                        showNotification(`Network error: could not ${action} user`, 'error');
+                    }
+                });
+
+                actionsWrapper.appendChild(txnBtn);
+                if (!isTeacherOrOwner) {
+                    actionsWrapper.appendChild(banBtn);
+                }
+                actionsTd.appendChild(actionsWrapper);
                 tr.appendChild(nameTd);
                 tr.appendChild(actionsTd);
                 tbody.appendChild(tr);


### PR DESCRIPTION
Introduce a user ban system across server and client:

- Database: add migration to create isBanned and permission columns on users if missing.
- Server/app: expose io via app.set('io') and check user ban status in socket events and Spotify routes (addToQueue, skip, purchaseShield) to block banned users. Update auth login to persist permission.
- Users routes: add ban/unban endpoints with checks to prevent banning teachers/owners, emit realtime userBanned/userUnbanned events, provide endpoints to list banned users and let current user check their ban status.
- Views/client: teacher panel UI to show banned/teacher badges and ban/unban buttons (no ban button for teachers/owners); player UI shows persistent ban banner, blocks actions if banned, and listens for realtime ban/unban events; song menu and leaderboard display ban indicators and client-side checks.

Also includes small SQL query updates to include isBanned/permission where needed and safety checks when emitting events. This ties backend enforcement with realtime frontend feedback for banned users.