### PR TITLE
Batch Spotify image fetch, add transliterate, debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
         "spotify-web-api-node": "^5.0.2",
-        "sqlite3": "^5.1.7"
+        "sqlite3": "^5.1.7",
+        "transliterate": "^1.0.1"
       },
       "devDependencies": {
         "concurrently": "^9.2.1",
@@ -3360,6 +3361,12 @@
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
+    },
+    "node_modules/transliterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/transliterate/-/transliterate-1.0.1.tgz",
+      "integrity": "sha512-axhGb0vNR1G+GWpUhT1mavr+r/ueIKVxhk3ABfOUuxmNE27O1PMsqu5G4GCy73DBvONf4KkZ5qxgyp5WXOWk7g==",
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "spotify-web-api-node": "^5.0.2",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "transliterate": "^1.0.1"
   },
   "devDependencies": {
     "concurrently": "^9.2.1",

--- a/utils/jukepix.js
+++ b/utils/jukepix.js
@@ -1,6 +1,7 @@
 
 require('dotenv').config({ quiet: true });
 
+const { transliterate } = require('transliterate');
 const spotifyApi = require('./spotify').spotifyApi;
 const db = require('./database');
 const apikey = process.env.JUKEPIX_API_KEY;
@@ -215,8 +216,8 @@ function displayTrack(track, settings = null) {
     if (!jukepixEnabled || !track) return;
 
     try {
-        const trackName = track.name || "No Track Playing";
-        const artistName = track.artist || "Unknown Artist";
+        const trackName = transliterate(track.name || "No Track Playing");
+        const artistName = transliterate(track.artist || "Unknown Artist");
         const displayText = `♪♫ ${trackName} - ${artistName} ♪♫        `;
 
         // Use resolved settings if provided, otherwise fall back to defaults

--- a/utils/queueManager.js
+++ b/utils/queueManager.js
@@ -534,24 +534,6 @@ class QueueManager {
                 };
             });
 
-            // For currently playing, use the FIRST (oldest) metadata entry
-            if (currentTrack) {
-                const metadataArray = metadataMap[currentTrack.uri];
-                if (metadataArray && metadataArray.length > 0) {
-                    // Find the metadata entry that's NOT in the queue anymore (it's playing)
-                    // This should be the one with the oldest added_at that doesn't match any queue position
-                    const metadata = metadataArray[0]; // First entry is the one currently playing
-
-                    currentTrack.addedBy = metadata.is_anon ? 'Anonymous' : metadata.added_by;
-                    currentTrack.displayName = metadata.is_anon ? 'Anonymous' : metadata.display_name;
-                    currentTrack.isAnon = metadata.is_anon;
-                    currentTrack.skipShields = metadata.skip_shields;
-                }
-                // Add frontend-compatible property names
-                currentTrack.progress = currentTrack.progress_ms;
-                currentTrack.duration = currentTrack.duration_ms;
-            }
-
             // Update internal state
             this.queue = newQueue;
             this.currentTrack = currentTrack;

--- a/views/teacher.ejs
+++ b/views/teacher.ejs
@@ -507,8 +507,20 @@
         });
     });
 
+    let searchDebounce = null;
+    document.getElementById('searchInput')?.addEventListener('input', () => {
+        clearTimeout(searchDebounce);
+        const query = document.getElementById('searchInput').value.trim();
+        if (!query) {
+            document.getElementById('searchResults').innerHTML = '';
+            return;
+        }
+        searchDebounce = setTimeout(() => searchSpotify(), 400);
+    });
+
     document.getElementById('searchForm')?.addEventListener('submit', (e) => {
         e.preventDefault();
+        clearTimeout(searchDebounce);
         searchSpotify();
     });
     // Ban/Unban button handler (event delegation)


### PR DESCRIPTION
This pull request introduces several improvements focused on performance, user experience, and internationalization. The most significant changes include optimizing Spotify album art fetching by batching requests, adding transliteration support for track and artist names, and enhancing the search input with debouncing. Additionally, a minor dependency update and some code cleanup were performed.

**Performance and API Optimization:**
- Batch fetches Spotify album art for queue history instead of making individual requests per track, significantly reducing API calls and improving response time. (`routes/users.js`)

**Internationalization:**
- Adds the `transliterate` package to dependencies and applies transliteration to track and artist names in the Jukepix display, ensuring names with non-Latin characters are shown more accessibly. (`package.json`, `utils/jukepix.js`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R12) [[2]](diffhunk://#diff-f4242fcda7b2cd451db149603e357034fa4149074a60d24477ac365a40d98549R4) [[3]](diffhunk://#diff-f4242fcda7b2cd451db149603e357034fa4149074a60d24477ac365a40d98549L218-R220)

**User Experience:**
- Implements debouncing on the search input in the teacher view to prevent excessive Spotify API calls while typing, improving frontend responsiveness. (`views/teacher.ejs`)

**Code Cleanup:**
- Removes unused logic for assigning metadata to the currently playing track in the queue manager, simplifying state management. (`utils/queueManager.js`)