### PR TITLE
Refund via owner PIN and pre-check duplicates

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -17,6 +17,7 @@ FORMBAR_ADDRESS=http://localhost:420
 
 
 OWNER_ID=your_owner_id(s)_here
+OWNER_PIN=only_first_listed_owner_pin
 
 POOL_ID=your_pool_id_here
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Jukebar",
+  "name": "jukebar",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/routes/payment.js
+++ b/routes/payment.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const db = require('../utils/database');
-const { isOwner } = require('../utils/owners');
+const { isOwner, getFirstOwnerId } = require('../utils/owners');
 const { transfer, refund: poolRefund } = require('../utils/transferManager');
 
 const FORMBAR_ADDRESS = process.env.FORMBAR_ADDRESS;
@@ -144,12 +144,20 @@ router.post('/transfer', async (req, res) => {
 
 router.post('/refund', async (req, res) => {
     try {
-        const from = POOL_ID;
         const reason = "Jukebar refund";
-        if (!from || isNaN(from)) {
-            return res.status(500).json({ ok: false, error: 'Server misconfigured: POOL_ID is not set. Contact your administrator.' });
+        
+        // Get the first owner's ID
+        const firstOwnerId = getFirstOwnerId();
+        if (!firstOwnerId) {
+            return res.status(500).json({ ok: false, error: 'Server misconfigured: No owner ID found' });
         }
-        const pin = process.env.PIN;
+        
+        // Get owner's PIN from environment variable
+        const pin = process.env.OWNER_PIN;
+        if (!pin) {
+            return res.status(500).json({ ok: false, error: 'Server misconfigured: OWNER_PIN not set' });
+        }
+        
         const userRow = await new Promise((resolve, reject) => {
             db.get("SELECT id FROM users WHERE id = ?", [req.session.token?.id], (err, row) => {
                 if (err) {
@@ -164,9 +172,6 @@ router.post('/refund', async (req, res) => {
         if (!userRow || !userRow.id) {
             return res.status(401).json({ ok: false, error: 'Not authenticated' });
         }
-        if (!from || pin == null) {
-            return res.status(500).json({ ok: false, error: 'Refund misconfigured on server' });
-        }
 
         // Require a recent, unclaimed payment to exist in session and prevent double-refunds
         const lastPayment = req.session.payment || null;
@@ -179,7 +184,7 @@ router.post('/refund', async (req, res) => {
         if (lastPayment.refundedAt) {
             return res.status(409).json({ ok: false, error: 'Payment already refunded' });
         }
-        if (lastPayment.from !== Number(userRow.id) || lastPayment.to !== from) {
+        if (lastPayment.from !== Number(userRow.id)) {
             return res.status(403).json({ ok: false, error: 'Payment does not belong to this user' });
         }
         if (!req.session.hasPaid) {
@@ -189,6 +194,9 @@ router.post('/refund', async (req, res) => {
         if (!lastPayment.at || (now - lastPayment.at) > refundableWindowMs) {
             return res.status(408).json({ ok: false, error: 'Refund window expired' });
         }
+        
+        // Refund comes from the first owner, not from the pool
+        const from = firstOwnerId;
 
         // Refund the exact amount of the last payment
         const amount = Number(lastPayment.amount);

--- a/routes/spotify.js
+++ b/routes/spotify.js
@@ -5,7 +5,7 @@ const db = require('../utils/database');
 const { logTransaction } = require('./logging');
 const queueManager = require('../utils/queueManager');
 const { isAuthenticated } = require('../middleware/auth');
-const { isOwner } = require('../utils/owners');
+const { isOwner, getFirstOwnerId } = require('../utils/owners');
 const { refund: poolRefund } = require('../utils/transferManager');
 const { exec } = require('child_process');
 const fs = require('fs');
@@ -417,6 +417,18 @@ router.post('/addToQueue', async (req, res) => {
         return res.status(403).json({ ok: false, error: 'You have been banned from using Jukebar. Contact your teacher.' });
     }
 
+    // Check for duplicates BEFORE payment (for non-teachers)
+    const isTeacher = req.session.permission >= 4 || isOwner(req.session.token.id);
+    if (!isTeacher) {
+        const { uri } = req.body;
+        if (uri) {
+            const isDuplicate = queueManager.queue.some(item => item.uri === uri);
+            if (isDuplicate) {
+                return res.status(400).json({ ok: false, error: 'This song is already in the queue. Please choose a different song.' });
+            }
+        }
+    }
+
     // For non-admin users, check payment
     if (!req.session.hasPaid) {
         //console.log('addToQueue - Payment required. User ID:', req.session.token.id, 'hasPaid:', req.session.hasPaid);
@@ -448,15 +460,6 @@ router.post('/addToQueue', async (req, res) => {
         // Check banned songs
         if (await isTrackBannedByNameArtist(trackInfo.name, trackInfo.artist)) {
             return res.status(403).json({ ok: false, error: 'This track has been banned by the teacher' });
-        }
-
-        // Prevent non-teachers from queuing a song that is already in the queue
-        const isTeacher = req.session.permission >= 4 || isOwner(req.session.token.id);
-        if (!isTeacher) {
-            const isDuplicate = queueManager.queue.some(item => item.uri === uri);
-            if (isDuplicate) {
-                return res.status(400).json({ ok: false, error: 'This song is already in the queue. Please choose a different song.' });
-            }
         }
 
         await spotifyApi.addToQueue(uri);

--- a/utils/transferManager.js
+++ b/utils/transferManager.js
@@ -40,7 +40,7 @@ function validateTransferParams({ from, to, amount, pin }) {
 }
 
 /**
- * Perform a pool-based transfer via Formbar socket.
+ * Perform a transfer via Formbar socket.
  * 
  * @param {object} params
  * @param {number} params.from   - Sender user ID
@@ -48,12 +48,17 @@ function validateTransferParams({ from, to, amount, pin }) {
  * @param {number} params.amount - Amount to transfer
  * @param {number} params.pin    - Sender's PIN
  * @param {string} params.reason - Reason for transfer
+ * @param {boolean} params.pool  - Whether this is a pool-based transfer (optional)
  * @returns {Promise<object>} Transfer response
  * @throws {Error} With message and optional .details property
  */
-async function transfer({ from, to, amount, pin, reason = 'Jukebar Payment' }) {
+async function transfer({ from, to, amount, pin, reason = 'Jukebar Payment', pool = false }) {
     // Step 1: Validate inputs
     validateTransferParams({ from, to, amount, pin });
+
+    // Auto-detect if transfer involves the pool
+    // Only mark as pool transfer if TO a pool, not just FROM a pool
+    const isPoolTransfer = pool || Number(to) === POOL_ID;
 
     const payload = {
         from: Number(from),
@@ -61,10 +66,10 @@ async function transfer({ from, to, amount, pin, reason = 'Jukebar Payment' }) {
         amount: Number(amount),
         reason: String(reason),
         pin: Number(pin),
-        pool: true // Pool-based transfer
+        pool: isPoolTransfer
     };
 
-    console.log('[TransferManager] Initiating pool transfer:', {
+    console.log('[TransferManager] Initiating transfer:', {
         from: payload.from,
         to: payload.to,
         amount: payload.amount,


### PR DESCRIPTION
Add OWNER_PIN to .env-template and update refund/payment behavior: refunds are now issued from the first listed owner (getFirstOwnerId) and use the OWNER_PIN env var; the refund route validates owner ID and PIN configuration and ensures the payment belongs to the authenticated user before refunding. In spotify route, duplicate-song checks for non-teacher users were moved before the payment step to prevent charging for songs already in the queue. transferManager was generalized to detect pool transfers automatically, accept an optional 'pool' flag, and adjusted payload/logging accordingly.