### PR TITLE
Use Spotify /items endpoint for playlist tracks

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -18,7 +18,7 @@ db.serialize(() => {
         UNIQUE(match_type, match_value, match_artist)
     )`, (err) => {
         if (err) console.error('jukepix_settings:', err.message);
-        else //console.log('jukepix_settings OK');
+        else console.log('jukepix_settings OK');
     });
 
     db.run(`CREATE TABLE IF NOT EXISTS jukepix_defaults (
@@ -36,12 +36,12 @@ db.serialize(() => {
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )`, (err) => {
         if (err) console.error('jukepix_defaults:', err.message);
-        else //console.log('jukepix_defaults OK');
+        else console.log('jukepix_defaults OK');
     });
 
     db.run(`INSERT OR IGNORE INTO jukepix_defaults (id) VALUES (1)`, (err) => {
         if (err) console.error('insert defaults:', err.message);
-        else //console.log('default row OK');
-        db.close(() => //console.log('Migration complete.'));
+        else console.log('default row OK');
+        db.close(() => console.log('Migration complete.'));
     });
 });

--- a/routes/customPlaylists.js
+++ b/routes/customPlaylists.js
@@ -343,9 +343,13 @@ router.get('/api/custom-playlists/:id/tracks', isAuthenticated, async (req, res)
         let offset = 0;
         const limit = 100;
 
+        // /tracks was renamed to /items in the Feb 2026 Spotify API changes
         while (true) {
-            const response = await spotifyApi.getPlaylistTracks(playlist.spotify_playlist_id, { limit, offset });
-            const items = response.body?.items || [];
+            const res = await fetch(`https://api.spotify.com/v1/playlists/${playlist.spotify_playlist_id}/items?limit=${limit}&offset=${offset}`, {
+                headers: { Authorization: `Bearer ${spotifyApi.getAccessToken()}` }
+            });
+            const data = await res.json();
+            const items = data?.items || [];
             tracks.push(...items.filter(item => item?.track && !item.track.is_local && item.track.uri?.startsWith('spotify:track:')));
             if (items.length < limit) break;
             offset += limit;

--- a/routes/payment.js
+++ b/routes/payment.js
@@ -49,9 +49,13 @@ async function fetchPlaylistTrackItems(playlistId) {
     let offset = 0;
     const limit = 100;
 
+    // /tracks was renamed to /items in the Feb 2026 Spotify API changes
     while (true) {
-        const response = await spotifyApi.getPlaylistTracks(playlistId, { limit, offset });
-        const batch = response.body?.items || [];
+        const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/items?limit=${limit}&offset=${offset}`, {
+            headers: { Authorization: `Bearer ${spotifyApi.getAccessToken()}` }
+        });
+        const data = await res.json();
+        const batch = data?.items || [];
         items.push(...batch);
         if (batch.length < limit) break;
         offset += limit;

--- a/routes/spotify.js
+++ b/routes/spotify.js
@@ -327,9 +327,13 @@ async function fetchPlaylistTracks(playlistId) {
     let offset = 0;
     const limit = 100;
 
+    // /tracks was renamed to /items in the Feb 2026 Spotify API changes
     while (true) {
-        const response = await spotifyApi.getPlaylistTracks(playlistId, { limit, offset });
-        const items = response.body?.items || [];
+        const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/items?limit=${limit}&offset=${offset}`, {
+            headers: { Authorization: `Bearer ${spotifyApi.getAccessToken()}` }
+        });
+        const data = await res.json();
+        const items = data?.items || [];
         tracks.push(...items);
         if (items.length < limit) break;
         offset += limit;


### PR DESCRIPTION
Update playlist track fetching to use Spotify's v1/playlists/{id}/items endpoint (Feb 2026 API change from /tracks -> /items) across routes/customPlaylists.js, routes/payment.js and routes/spotify.js. Replace spotifyApi.getPlaylistTracks calls with fetch requests that pass Authorization: Bearer <token> via spotifyApi.getAccessToken(), and adjust response parsing to read data.items. Also re-enable migration logging in migrate.js so table creation, default row insertion, and migration completion are logged.