### PR TITLE
Fix playlist track count bug in spotify.js

### DIFF
--- a/routes/spotify.js
+++ b/routes/spotify.js
@@ -680,7 +680,7 @@ router.get('/api/spotify/playlists', isAuthenticated, requireTeacherAccess, asyn
             const formatted = {
             id: playlist.id,
             name: playlist.name || 'Untitled Playlist',
-            totalTracks: playlist.tracks?.total ?? 0,
+            totalTracks: playlist.items?.total ?? playlist.tracks?.total ?? 0,
             image: playlist.images?.[0]?.url || null,
             owner: playlist.owner?.display_name || playlist.owner?.id || 'Unknown',
             url: playlist.external_urls?.spotify || null,
@@ -878,7 +878,7 @@ router.post('/api/playlists/queue', isAuthenticated, async (req, res) => {
         }
 
         if (!queueableCount) {
-            return res.status(400).json({ ok: false, error: 'No queueable tracks found in this playlist', skipped: queueData.skipped });
+            return res.status(400).json({ ok: false, error: 'No queueable tracks found in this playlist', skipped: playlistStats.skipped });
         }
 
         const username = typeof req.session.user === 'string' ? req.session.user : String(req.session.user || 'Spotify');


### PR DESCRIPTION
This pull request makes minor improvements to the Spotify playlist API routes, focusing on more robust data handling and clearer error reporting.

- Playlist Data Handling:
  * In the `/api/spotify/playlists` endpoint, the `totalTracks` property now checks for `playlist.items?.total` before falling back to `playlist.tracks?.total`, improving compatibility with different playlist data structures.

- Error Reporting:
  * In the `/api/playlists/queue` endpoint, the error response for "No queueable tracks found" now returns the `skipped` property from `playlistStats` instead of `queueData`, ensuring more accurate error details.