### PR TITLE
Add track image support and teacher clear-queue feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -161,9 +161,10 @@ io.on('connection', (socket) => {
     // Handle ban vote initiation
     socket.on('initiateBanVote', async (data) => {
         try {
-            const { trackUri, trackName, trackArtist, initiator, reason } = data;
+            const { trackUri, trackName, trackArtist, initiator, reason, trackImage } = data;
             const userId = socket.request?.session?.token?.id || socket.id;
             const banReason = (typeof reason === 'string' && reason.trim()) ? reason.trim() : 'student ban';
+            const imageUrl = typeof trackImage === 'string' ? trackImage : null;
 
             if (banReason.length > 200) {
                 socket.emit('banVoteError', { error: 'Ban reason must be 200 characters or fewer' });
@@ -242,10 +243,9 @@ io.on('connection', (socket) => {
                 async (expiredData) => {
                     if (expiredData.passed) {
                         console.log('Vote expired with pass, broadcasting banVotePassed:', expiredData);
-                        // Insert into banned_songs table
                         db.run(
-                            'INSERT INTO banned_songs (track_name, artist_name, banned_by, reason, track_uri) VALUES (?, ?, ?, ?, ?)',
-                            [expiredData.trackName, expiredData.trackArtist, expiredData.userId, expiredData.reason, expiredData.trackUri],
+                            'INSERT INTO banned_songs (track_name, artist_name, banned_by, reason, track_uri, image_url) VALUES (?, ?, ?, ?, ?, ?)',
+                            [expiredData.trackName, expiredData.trackArtist, expiredData.userId, expiredData.reason, expiredData.trackUri, imageUrl],
                             async (err) => {
                                 if (err) {
                                     console.error('Database insertion error (ban on expiration):', err);
@@ -261,7 +261,8 @@ io.on('connection', (socket) => {
                         console.log('Vote expired, broadcasting banVoteFailed:', expiredData);
                         io.emit('banVoteFailed', expiredData);
                     }
-                }
+                },
+                { imageUrl }
             );
 
             // Broadcast to all clients
@@ -304,8 +305,8 @@ io.on('connection', (socket) => {
                     await new Promise((resolve, reject) => {
                         console.log('Inserting into banned_songs:', result.trackName, result.trackArtist);
                         db.run(
-                            'INSERT INTO banned_songs (track_name, artist_name, banned_by, reason) VALUES (?, ?, ?, ?)',
-                            [result.trackName, result.trackArtist, result.userId, result.reason],
+                            'INSERT INTO banned_songs (track_name, artist_name, banned_by, reason, track_uri, image_url) VALUES (?, ?, ?, ?, ?, ?)',
+                            [result.trackName, result.trackArtist, result.userId, result.reason, result.trackUri || null, result.extra?.imageUrl || null],
                             (err) => {
                                 if (err) {
                                     console.error('Database insertion error:', err);

--- a/routes/logging.js
+++ b/routes/logging.js
@@ -1,10 +1,10 @@
 const db = require("../utils/database");
 
-async function logTransaction({ userID, displayName, action, trackURI = null, trackName = null, artistName = null, cost }) {
+async function logTransaction({ userID, displayName, action, trackURI = null, trackName = null, artistName = null, imageURL = null, cost }) {
     return new Promise((resolve, reject) => {
-        const query = `INSERT INTO transactions (user_id, display_name, action, track_uri, track_name, artist_name, cost) 
-                       VALUES (?, ?, ?, ?, ?, ?, ?)`;
-        const params = [userID, displayName, action, trackURI, trackName, artistName, cost];
+        const query = `INSERT INTO transactions (user_id, display_name, action, track_uri, track_name, artist_name, image_url, cost) 
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+        const params = [userID, displayName, action, trackURI, trackName, artistName, imageURL, cost];
         db.run(query, params, function (err) {
             if (err) {
                 console.error('Error logging transaction:', err);

--- a/routes/payment.js
+++ b/routes/payment.js
@@ -49,15 +49,27 @@ async function fetchPlaylistTrackItems(playlistId) {
     let offset = 0;
     const limit = 100;
 
-    // /tracks was renamed to /items in the Feb 2026 Spotify API changes
     while (true) {
         const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/items?limit=${limit}&offset=${offset}`, {
             headers: { Authorization: `Bearer ${spotifyApi.getAccessToken()}` }
         });
+
+        if (!res.ok) {
+            const body = await res.text();
+            console.error(`[payment:fetchPlaylistTrackItems] Spotify returned ${res.status} at offset=${offset}: ${body}`);
+            if (res.status === 403) {
+                throw new Error('Spotify denied access to this playlist. The connected Spotify account must own or collaborate on the playlist (Feb 2026 API change).');
+            } else if (res.status === 429) {
+                const retryAfter = res.headers.get('retry-after');
+                throw new Error(`Rate limited by Spotify. Try again in ${retryAfter || 'a few'} seconds.`);
+            }
+            throw new Error(`Spotify returned HTTP ${res.status} when fetching playlist tracks.`);
+        }
+
         const data = await res.json();
         const batch = data?.items || [];
         items.push(...batch);
-        if (batch.length < limit) break;
+        if (batch.length < limit || (data?.total && items.length >= data.total)) break;
         offset += limit;
     }
 

--- a/routes/spotify.js
+++ b/routes/spotify.js
@@ -99,7 +99,23 @@ let currentTrack = null;
 
 // Helper function to handle Spotify API errors consistently
 function handleSpotifyError(error, res, action = 'operation') {
-    const errMsg = error?.message || error?.body?.error?.message || String(error);
+    // spotify-web-api-node WebapiError sets error.message = String(body) when the body object
+    // is passed directly to Error(), producing the sentinel "[object Object]".
+    // Fall through it and extract from error.body instead.
+    const rawMsg = error?.message;
+    let errMsg;
+    if (typeof rawMsg === 'string' && rawMsg && rawMsg !== '[object Object]') {
+        errMsg = rawMsg;
+    } else {
+        const bodyMsg = error?.body?.error?.message;
+        if (typeof bodyMsg === 'string' && bodyMsg) {
+            errMsg = bodyMsg;
+        } else if (error?.body && typeof error.body === 'object') {
+            try { errMsg = JSON.stringify(error.body); } catch { errMsg = String(error); }
+        } else {
+            errMsg = String(error);
+        }
+    }
     console.error(`Spotify ${action} error [${error?.statusCode ?? 'unknown'}]: ${errMsg}`);
 
     // Handle network connectivity errors
@@ -327,20 +343,37 @@ async function fetchPlaylistTracks(playlistId) {
     const tracks = [];
     let offset = 0;
     const limit = 100;
+    let fetchError = null;
 
-    // /tracks was renamed to /items in the Feb 2026 Spotify API changes
     while (true) {
         const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/items?limit=${limit}&offset=${offset}`, {
             headers: { Authorization: `Bearer ${spotifyApi.getAccessToken()}` }
         });
+
+        if (!res.ok) {
+            const body = await res.text();
+            console.error(`[fetchPlaylistTracks] Spotify returned ${res.status} at offset=${offset}: ${body}`);
+            if (res.status === 403) {
+                fetchError = { status: 403, message: 'Spotify denied access to this playlist. The connected Spotify account must own or collaborate on the playlist (Feb 2026 API change).' };
+            } else if (res.status === 429) {
+                const retryAfter = res.headers.get('retry-after');
+                console.warn(`[fetchPlaylistTracks] Rate limited. Retry-After: ${retryAfter}s`);
+                fetchError = { status: 429, message: `Rate limited by Spotify. Try again in ${retryAfter || 'a few'} seconds.` };
+            } else {
+                fetchError = { status: res.status, message: `Spotify returned HTTP ${res.status} when fetching playlist tracks.` };
+            }
+            break;
+        }
+
         const data = await res.json();
         const items = data?.items || [];
+        console.log(`[fetchPlaylistTracks] offset=${offset} fetched=${items.length} total=${data?.total ?? '?'}`);
         tracks.push(...items);
-        if (items.length < limit) break;
+        if (items.length < limit || (data?.total && tracks.length >= data.total)) break;
         offset += limit;
     }
 
-    return tracks;
+    return { tracks, error: fetchError };
 }
 
 function computePlaylistCost(trackCount) {
@@ -356,11 +389,12 @@ async function getQueueUriSet() {
 }
 
 async function getQueueablePlaylistTracks(playlistId) {
-    const [rawItems, bannedSongs, queueUris] = await Promise.all([
+    const [fetchResult, bannedSongs, queueUris] = await Promise.all([
         fetchPlaylistTracks(playlistId),
         getBannedSongs(),
         getQueueUriSet()
     ]);
+    const rawItems = fetchResult.tracks;
 
     const bannedPairs = new Set(
         (bannedSongs || []).map((row) => `${(row.track_name || '').trim().toLowerCase()}::${(row.artist_name || '').trim().toLowerCase()}`)
@@ -402,18 +436,26 @@ async function getQueueablePlaylistTracks(playlistId) {
 }
 
 async function getPlaylistPlayableStats(playlistId) {
-    const rawItems = await fetchPlaylistTracks(playlistId);
+    const { tracks: rawItems, error: fetchError } = await fetchPlaylistTracks(playlistId);
+
+    if (fetchError) {
+        console.error(`[getPlaylistPlayableStats] fetch failed for ${playlistId}: ${fetchError.message}`);
+        return { playableCount: 0, fetchError, skipped: { unplayable: 0, banned: 0, duplicate: 0 } };
+    }
+
     let playableCount = 0;
     let unplayableCount = 0;
 
     for (const item of rawItems) {
-        const track = item?.item ?? item?.track; // .track renamed to .item in Feb 2026 Spotify API changes
+        const track = item?.item ?? item?.track;
         if (!track || track.is_local || !track.uri || !track.uri.startsWith('spotify:track:')) {
             unplayableCount += 1;
             continue;
         }
         playableCount += 1;
     }
+
+    console.log(`[getPlaylistPlayableStats] playlistId=${playlistId} rawItems=${rawItems.length} playable=${playableCount} unplayable=${unplayableCount}`);
 
     return {
         playableCount,
@@ -435,7 +477,7 @@ async function isPlaylistCurrentlyPlaying(playlistId) {
     const currentTrackUri = await getCurrentTrackUri();
     if (!currentTrackUri) return false;
 
-    const playlistItems = await fetchPlaylistTracks(playlistId);
+    const { tracks: playlistItems } = await fetchPlaylistTracks(playlistId);
     return playlistItems.some((item) => (item?.item ?? item?.track)?.uri === currentTrackUri);
 }
 
@@ -579,9 +621,11 @@ router.get('/recentlyQueued', async (req, res) => {
     try {
         const rows = await new Promise((resolve, reject) => {
             db.all(
-                `SELECT track_uri, track_name, artist_name FROM transactions 
-                 WHERE user_id = ? AND action = 'play' 
-                 ORDER BY timestamp DESC LIMIT 200`,
+                `SELECT t.track_uri, t.track_name, t.artist_name, t.image_url FROM transactions t
+                 LEFT JOIN users u ON u.id = t.user_id
+                 WHERE t.user_id = ? AND t.action = 'play'
+                   AND (u.recently_queued_cleared_at IS NULL OR t.timestamp > u.recently_queued_cleared_at)
+                 ORDER BY t.timestamp DESC LIMIT 200`,
                 [req.session.token.id],
                 (err, rows) => err ? reject(err) : resolve(rows || [])
             );
@@ -603,7 +647,7 @@ router.get('/recentlyQueued', async (req, res) => {
             name: r.track_name || 'Unknown',
             artist: r.artist_name || 'Unknown',
             uri: r.track_uri,
-            album: { name: '', image: null }
+            album: { name: '', image: r.image_url || '' }
         }));
 
         return res.json({ ok: true, tracks });
@@ -621,7 +665,7 @@ router.post('/clearQueueHistory', async (req, res) => {
     try {
         await new Promise((resolve, reject) => {
             db.run(
-                `DELETE FROM transactions WHERE user_id = ? AND action = 'play'`,
+                `UPDATE users SET recently_queued_cleared_at = datetime('now') WHERE id = ?`,
                 [req.session.token.id],
                 (err) => err ? reject(err) : resolve()
             );
@@ -640,11 +684,36 @@ router.post('/clearQueueHistory', async (req, res) => {
     }
 });
 
+// Teacher-only: clear recently queued for ALL users (transactions stay intact)
+router.post('/clearAllRecentlyQueued', isAuthenticated, requireTeacherAccess, async (req, res) => {
+    try {
+        await new Promise((resolve, reject) => {
+            db.run(
+                `UPDATE users SET recently_queued_cleared_at = datetime('now')`,
+                (err) => err ? reject(err) : resolve()
+            );
+        });
+
+        const io = req.app.get('io');
+        if (io) io.emit('recentlyQueuedCleared');
+
+        return res.json({ ok: true, message: 'Recently queued cleared for all users' });
+    } catch (err) {
+        console.error('Error clearing all recently queued:', err);
+        return res.status(500).json({ ok: false, error: 'Failed to clear recently queued' });
+    }
+});
+
 router.get('/api/spotify/playlists', isAuthenticated, requireTeacherAccess, async (req, res) => {
     try {
         await ensureSpotifyAccessToken();
         const classId = await getClassId();
-        const items = await fetchAllUserPlaylists();
+
+        const [items, meData] = await Promise.all([
+            fetchAllUserPlaylists(),
+            spotifyApi.getMe().catch(() => null)
+        ]);
+        const myId = meData?.body?.id;
 
         const removedCount = await pruneAllowedPlaylistsNotInLibrary(
             classId,
@@ -657,15 +726,18 @@ router.get('/api/spotify/playlists', isAuthenticated, requireTeacherAccess, asyn
         const allowedMap = await getAllowedPlaylistMap(classId);
 
         const playlists = items.map((playlist) => {
+            const ownerId = playlist.owner?.id;
+            const collaborative = !!playlist.collaborative;
             const formatted = {
             id: playlist.id,
             name: playlist.name || 'Untitled Playlist',
             totalTracks: playlist.items?.total ?? playlist.tracks?.total ?? 0,
             image: playlist.images?.[0]?.url || null,
-            owner: playlist.owner?.display_name || playlist.owner?.id || 'Unknown',
+            owner: playlist.owner?.display_name || ownerId || 'Unknown',
             url: playlist.external_urls?.spotify || null,
             uri: playlist.uri,
-            isAllowed: allowedMap.get(playlist.id) || false
+            isAllowed: allowedMap.get(playlist.id) || false,
+            canAccessTracks: (myId && ownerId === myId) || collaborative
             };
             return formatted;
         });
@@ -775,6 +847,11 @@ router.post('/api/playlists/quote', isAuthenticated, async (req, res) => {
             getPlaylistPlayableStats(playlistId)
         ]);
 
+        if (playlistStats.fetchError) {
+            const fe = playlistStats.fetchError;
+            return res.status(fe.status === 403 ? 403 : fe.status === 429 ? 429 : 502).json({ ok: false, error: fe.message });
+        }
+
         const queueableCount = playlistStats.playableCount;
         const cost = computePlaylistCost(queueableCount);
 
@@ -857,6 +934,11 @@ router.post('/api/playlists/queue', isAuthenticated, async (req, res) => {
             }
         }
 
+        if (playlistStats.fetchError) {
+            const fe = playlistStats.fetchError;
+            return res.status(fe.status === 403 ? 403 : fe.status === 429 ? 429 : 502).json({ ok: false, error: fe.message });
+        }
+
         if (!queueableCount) {
             return res.status(400).json({ ok: false, error: 'No queueable tracks found in this playlist', skipped: playlistStats.skipped });
         }
@@ -932,7 +1014,7 @@ router.post('/unbanTrack', isAuthenticated, requireTeacherAccess, async (req, re
 // Teacher-only: Ban a track by name/artist (optionally record URI)
 router.post('/banTrack', isAuthenticated, requireTeacherAccess, async (req, res) => {
     try {
-        const { name, artist, reason, uri } = req.body || {};
+        const { name, artist, reason, uri, image } = req.body || {};
         if (!name || !artist) return res.status(400).json({ ok: false, error: 'Missing track name or artist' });
 
         const banReason = typeof reason === 'string' ? reason.trim() : '';
@@ -950,10 +1032,12 @@ router.post('/banTrack', isAuthenticated, requireTeacherAccess, async (req, res)
             return res.json({ ok: true, message: 'Track already banned' });
         }
 
+        const imageUrl = typeof image === 'string' ? image : null;
+
         await new Promise((resolve, reject) => {
             db.run(
-                'INSERT INTO banned_songs (track_name, artist_name, track_uri, banned_by, reason) VALUES (?, ?, ?, ?, ?)',
-                [name, artist, uri || null, bannedBy, banReason],
+                'INSERT INTO banned_songs (track_name, artist_name, track_uri, banned_by, reason, image_url) VALUES (?, ?, ?, ?, ?, ?)',
+                [name, artist, uri || null, bannedBy, banReason, imageUrl],
                 function (err) {
                     if (err) return reject(err);
                     resolve();
@@ -1070,7 +1154,7 @@ router.post('/addToQueue', async (req, res) => {
         try {
             await ensureSpotifyAccessToken();
 
-            const { uri, anonMode } = req.body;
+            const { uri, anonMode, trackName: clientName, trackArtist: clientArtist, trackImage: clientImage } = req.body;
             if (!uri) return res.status(400).json({ error: "Missing track URI" });
 
             const trackIdPattern = /^spotify:track:([a-zA-Z0-9]{22})$/;
@@ -1079,8 +1163,22 @@ router.post('/addToQueue', async (req, res) => {
 
             const trackId = match[1];
 
-            const trackData = await spotifyApi.getTrack(trackId);
-            const track = trackData.body;
+            // Use client-supplied metadata when available to avoid an extra Spotify API call.
+            // Fall back to getTrack() only when metadata is missing (e.g. direct API calls).
+            const trimName = typeof clientName === 'string' ? clientName.trim() : '';
+            const trimArtist = typeof clientArtist === 'string' ? clientArtist.trim() : '';
+            let track;
+            if (trimName && trimArtist) {
+                track = {
+                    name: trimName.slice(0, 200),
+                    artists: [{ name: trimArtist.slice(0, 200) }],
+                    uri,
+                    album: { images: [{ url: typeof clientImage === 'string' ? clientImage : '' }] }
+                };
+            } else {
+                const trackData = await spotifyApi.getTrack(trackId);
+                track = trackData.body;
+            }
             const username = typeof req.session.user === 'string' ? req.session.user : String(req.session.user || 'Spotify');
             const isAnon = anonMode ? 1 : 0;
 
@@ -1088,7 +1186,7 @@ router.post('/addToQueue', async (req, res) => {
                 name: track.name,
                 artist: track.artists.map(a => a.name).join(', '),
                 uri: track.uri,
-                cover: track.album.images[0].url,
+                cover: track.album.images[0]?.url || '',
                 addedBy: username
             };
 
@@ -1150,6 +1248,7 @@ router.post('/addToQueue', async (req, res) => {
                 trackURI: trackInfo.uri,
                 trackName: trackInfo.name,
                 artistName: trackInfo.artist,
+                imageURL: trackInfo.cover || null,
                 cost: 0
             });
 
@@ -1204,7 +1303,7 @@ router.post('/addToQueue', async (req, res) => {
     try {
         await ensureSpotifyAccessToken();
 
-        const { uri, anonMode } = req.body;
+        const { uri, anonMode, trackName: clientName, trackArtist: clientArtist, trackImage: clientImage } = req.body;
         if (!uri) return res.status(400).json({ error: "Missing track URI" });
 
         const trackIdPattern = /^spotify:track:([a-zA-Z0-9]{22})$/;
@@ -1213,14 +1312,28 @@ router.post('/addToQueue', async (req, res) => {
 
         const trackId = match[1];
 
-        const trackData = await spotifyApi.getTrack(trackId);
-        const track = trackData.body;
+        // Use client-supplied metadata when available to avoid an extra Spotify API call.
+        // Fall back to getTrack() only when metadata is missing (e.g. direct API calls).
+        const trimName = typeof clientName === 'string' ? clientName.trim() : '';
+        const trimArtist = typeof clientArtist === 'string' ? clientArtist.trim() : '';
+        let track;
+        if (trimName && trimArtist) {
+            track = {
+                name: trimName.slice(0, 200),
+                artists: [{ name: trimArtist.slice(0, 200) }],
+                uri,
+                album: { images: [{ url: typeof clientImage === 'string' ? clientImage : '' }] }
+            };
+        } else {
+            const trackData = await spotifyApi.getTrack(trackId);
+            track = trackData.body;
+        }
         const isAnon = anonMode ? 1 : 0;
         const trackInfo = {
             name: track.name,
             artist: track.artists.map(a => a.name).join(', '),
             uri: track.uri,
-            cover: track.album.images[0].url,
+            cover: track.album.images[0]?.url || '',
         };
 
         // Check banned songs
@@ -1286,6 +1399,7 @@ router.post('/addToQueue', async (req, res) => {
             trackURI: trackInfo.uri,
             trackName: trackInfo.name,
             artistName: trackInfo.artist,
+            imageURL: trackInfo.cover || null,
             cost: Number(process.env.SONG_AMOUNT) || 50
         });
 
@@ -1956,6 +2070,21 @@ router.get('/diagnostics', isAuthenticated, requireTeacherAccess, async (req, re
         tests: {}
     };
 
+    // spotify-web-api-node WebapiError sets error.message = String(body) when the body
+    // object is passed directly to the Error constructor, producing "[object Object]".
+    // Fall through that sentinel and extract from error.body instead.
+    function extractErrMsg(error, fallback) {
+        const raw = error?.message;
+        if (typeof raw === 'string' && raw && raw !== '[object Object]') return raw;
+        // WebapiError stores the original response body in .body
+        const bodyMsg = error?.body?.error?.message;
+        if (typeof bodyMsg === 'string' && bodyMsg) return bodyMsg;
+        if (error?.body && typeof error.body === 'object') {
+            try { return JSON.stringify(error.body); } catch { /* circular ref — ignore */ }
+        }
+        return fallback;
+    }
+
     try {
         await ensureSpotifyAccessToken();
 
@@ -1973,7 +2102,7 @@ router.get('/diagnostics', isAuthenticated, requireTeacherAccess, async (req, re
         } catch (error) {
             results.tests.userAccess = {
                 status: 'fail',
-                message: error.message || 'Failed to get user info',
+                message: extractErrMsg(error, 'Failed to get user info'),
                 statusCode: error.statusCode,
                 errorBody: error.body?.error || null
             };
@@ -1989,28 +2118,28 @@ router.get('/diagnostics', isAuthenticated, requireTeacherAccess, async (req, re
             };
         } catch (error) {
             results.tests.searchScope = {
-                status: 'fail',
-                message: error.message || 'Search failed',
+                status: error.statusCode === 429 ? 'warning' : 'fail',
+                message: extractErrMsg(error, 'Search failed'),
                 statusCode: error.statusCode,
                 errorBody: error.body?.error || null
             };
         }
 
-        // Test 3: getTracks - verify album art / playlist-read scope
+        // Test 3: getTrack - verify track metadata access
         try {
-            // Use a well-known Spotify track ID
             const trackResult = await spotifyApi.getTrack('3n3Ppam7vgaVa1iaRUc9Lp');
-            results.tests.albumArtLookup = {
+            results.tests.trackLookup = {
                 status: 'pass',
                 message: 'Track lookup working',
                 track: trackResult.body?.name || 'Unknown',
                 hasImage: !!(trackResult.body?.album?.images?.length > 0)
             };
         } catch (error) {
-            results.tests.albumArtLookup = {
-                status: 'fail',
-                message: error.message || 'Track lookup failed',
+            results.tests.trackLookup = {
+                status: error.statusCode === 429 ? 'warning' : 'fail',
+                message: extractErrMsg(error, 'Track lookup failed'),
                 statusCode: error.statusCode,
+                note: error.statusCode === 429 ? 'Rate limited — app is making too many requests. Wait and retry.' : undefined,
                 errorBody: error.body?.error || null
             };
         }
@@ -2027,8 +2156,8 @@ router.get('/diagnostics', isAuthenticated, requireTeacherAccess, async (req, re
             };
         } catch (error) {
             results.tests.playbackRead = {
-                status: 'fail',
-                message: error.message || 'Failed to read playback state',
+                status: error.statusCode === 429 ? 'warning' : 'fail',
+                message: extractErrMsg(error, 'Failed to read playback state'),
                 statusCode: error.statusCode,
                 errorBody: error.body?.error || null
             };
@@ -2037,7 +2166,7 @@ router.get('/diagnostics', isAuthenticated, requireTeacherAccess, async (req, re
         // Test 5: addToQueue - verify playback-modify scope (dry-run check)
         try {
             // We won't actually add to queue, just check if the scope is available
-            // by attempting a getMyCurrentPlaybackState call which requires user-modify-playback-state
+            // by attempting a getMyDevices call which requires user-read-playback-state
             const deviceResult = await spotifyApi.getMyDevices();
             const hasDevice = (deviceResult.body?.devices?.length || 0) > 0;
             results.tests.playbackModify = {
@@ -2048,8 +2177,8 @@ router.get('/diagnostics', isAuthenticated, requireTeacherAccess, async (req, re
             };
         } catch (error) {
             results.tests.playbackModify = {
-                status: 'fail',
-                message: error.message || 'Failed to check playback modify scope',
+                status: error.statusCode === 429 ? 'warning' : 'fail',
+                message: extractErrMsg(error, 'Failed to check playback modify scope'),
                 statusCode: error.statusCode,
                 errorBody: error.body?.error || null
             };

--- a/routes/users.js
+++ b/routes/users.js
@@ -52,6 +52,7 @@ router.get('/api/queueHistory', isAuthenticated, requireTeacherAccess, async (re
                     t.track_name,
                     t.artist_name,
                     t.track_uri,
+                    t.image_url,
                     t.display_name as user,
                     t.timestamp,
                     datetime(t.timestamp) as formatted_time
@@ -70,7 +71,7 @@ router.get('/api/queueHistory', isAuthenticated, requireTeacherAccess, async (re
 
         const enrichedPlays = plays.map(play => ({
             ...play,
-            albumImage: '/img/placeholder.png'
+            albumImage: play.image_url || ''
         }));
 
         res.json({ ok: true, plays: enrichedPlays });
@@ -95,7 +96,13 @@ router.get('/api/banned-songs', isAuthenticated, requireTeacherAccess, async (re
                     b.reason,
                     b.banned_by,
                     b.timestamp,
-                    u.displayName AS banned_by_name
+                    u.displayName AS banned_by_name,
+                    COALESCE(
+                        NULLIF(b.image_url, ''),
+                        (SELECT t.image_url FROM transactions t
+                         WHERE t.track_uri = b.track_uri AND t.image_url IS NOT NULL AND t.image_url != ''
+                         ORDER BY t.timestamp DESC LIMIT 1)
+                    ) AS image_url
                 FROM banned_songs b
                 LEFT JOIN users u ON u.id = CAST(b.banned_by AS INTEGER)
                 ORDER BY datetime(b.timestamp) DESC, b.id DESC
@@ -120,7 +127,7 @@ router.get('/api/banned-songs', isAuthenticated, requireTeacherAccess, async (re
                 banned_by: song.banned_by,
                 banned_by_name: bannedByDisplay,
                 timestamp: song.timestamp,
-                album_image: '/img/placeholder.png'
+                album_image: song.image_url || ''
             };
         });
 
@@ -298,9 +305,9 @@ router.post('/api/users/transactions', isAuthenticated, requireTeacherAccess, as
             return res.status(404).json({ error: 'User not found' });
         }
 
-        // Get total count of transactions for this user
+        // Get total count of play transactions for this user
         const totalCount = await new Promise((resolve, reject) => {
-            db.get("SELECT COUNT(*) as count FROM transactions WHERE user_id = ?", [user.id], (err, row) => {
+            db.get("SELECT COUNT(*) as count FROM transactions WHERE user_id = ? AND action = 'play'", [user.id], (err, row) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -309,7 +316,7 @@ router.post('/api/users/transactions', isAuthenticated, requireTeacherAccess, as
             });
         });
 
-        // Get paginated transactions for this user
+        // Get paginated play transactions for this user
         const transactions = await new Promise((resolve, reject) => {
             db.all(`
                 SELECT 
@@ -317,10 +324,11 @@ router.post('/api/users/transactions', isAuthenticated, requireTeacherAccess, as
                     artist_name,
                     action,
                     cost,
+                    image_url,
                     timestamp,
                     datetime(timestamp) as formatted_time
                 FROM transactions 
-                WHERE user_id = ? 
+                WHERE user_id = ? AND action = 'play'
                 ORDER BY timestamp DESC 
                 LIMIT ? OFFSET ?
             `, [user.id, limitNum, offset], (err, rows) => {
@@ -384,9 +392,9 @@ router.post('/api/users/transactions/modal', isAuthenticated, requireTeacherAcce
             return res.status(404).json({ error: 'User not found' });
         }
 
-        // Get total count of transactions for this user
+        // Get total count of play transactions for this user
         const totalCount = await new Promise((resolve, reject) => {
-            db.get("SELECT COUNT(*) as count FROM transactions WHERE user_id = ?", [user.id], (err, row) => {
+            db.get("SELECT COUNT(*) as count FROM transactions WHERE user_id = ? AND action = 'play'", [user.id], (err, row) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -395,7 +403,7 @@ router.post('/api/users/transactions/modal', isAuthenticated, requireTeacherAcce
             });
         });
 
-        // Get paginated transactions for this user
+        // Get paginated play transactions for this user
         const transactions = await new Promise((resolve, reject) => {
             db.all(`
                 SELECT 
@@ -403,10 +411,11 @@ router.post('/api/users/transactions/modal', isAuthenticated, requireTeacherAcce
                     artist_name,
                     action,
                     cost,
+                    image_url,
                     timestamp,
                     datetime(timestamp) as formatted_time
                 FROM transactions 
-                WHERE user_id = ? 
+                WHERE user_id = ? AND action = 'play'
                 ORDER BY timestamp DESC 
                 LIMIT ? OFFSET ?
             `, [user.id, limitNum, offset], (err, rows) => {

--- a/utils/database.js
+++ b/utils/database.js
@@ -50,6 +50,16 @@ db.all("PRAGMA table_info(users)", (err, columns) => {
             }
         });
     }
+    const hasClearedAt = columns && columns.some(c => c.name === 'recently_queued_cleared_at');
+    if (!hasClearedAt) {
+        db.run("ALTER TABLE users ADD COLUMN recently_queued_cleared_at TEXT", (alterErr) => {
+            if (alterErr) {
+                console.error('Error adding recently_queued_cleared_at column:', alterErr);
+            } else {
+                console.log('Added recently_queued_cleared_at column to users table');
+            }
+        });
+    }
 });
 
 db.run(`CREATE TABLE IF NOT EXISTS transactions (
@@ -60,16 +70,29 @@ db.run(`CREATE TABLE IF NOT EXISTS transactions (
     track_uri TEXT,
     track_name TEXT,
     artist_name TEXT,
+    image_url TEXT,
     cost INTEGER NOT NULL,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id)
 )`);
+
+// Auto-migrate: add image_url column if it doesn't exist yet (added for recently-queued album art)
+db.all("PRAGMA table_info(transactions)", (err, cols) => {
+    if (err || !cols) return;
+    if (!cols.some(c => c.name === 'image_url')) {
+        db.run("ALTER TABLE transactions ADD COLUMN image_url TEXT", (alterErr) => {
+            if (alterErr) console.error('Error adding image_url to transactions:', alterErr);
+            else console.log('Added image_url column to transactions table');
+        });
+    }
+});
 
 db.run(`CREATE TABLE IF NOT EXISTS banned_songs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     track_name TEXT NOT NULL,
     artist_name TEXT NOT NULL,
     track_uri TEXT,
+    image_url TEXT,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
     banned_by TEXT NOT NULL DEFAULT 'unknown',
     reason TEXT DEFAULT 'No reason given'
@@ -102,6 +125,9 @@ db.all("PRAGMA table_info(banned_songs)", (err, columns) => {
     }
     if (!hasColumn('reason')) {
         migrations.push("ALTER TABLE banned_songs ADD COLUMN reason TEXT DEFAULT 'No reason given'");
+    }
+    if (!hasColumn('image_url')) {
+        migrations.push("ALTER TABLE banned_songs ADD COLUMN image_url TEXT");
     }
 
     if (migrations.length === 0) {

--- a/utils/voteManager.js
+++ b/utils/voteManager.js
@@ -26,7 +26,7 @@ class VoteManager {
         };
     }
 
-    startBanVote(voteId, trackUri, trackName, trackArtist, banReason, initiator, onlineCount, onExpireCallback) {
+    startBanVote(voteId, trackUri, trackName, trackArtist, banReason, initiator, onlineCount, onExpireCallback, extra = {}) {
         const requiredVotes = Math.ceil(onlineCount / 2); // Simple majority
 
         console.log(`Starting ban vote: onlineCount=${onlineCount}, requiredVotes=${requiredVotes}`);
@@ -40,6 +40,7 @@ class VoteManager {
             initiator,
             onlineCount,
             requiredVotes,
+            extra,
             yesVotes: new Set([initiator]), // Initiator automatically votes yes
             noVotes: new Set(),
             startTime: Date.now(),
@@ -146,7 +147,8 @@ class VoteManager {
                 trackArtist: voteData.trackArtist,
                 reason: voteData.banReason,
                 outcomeReason: 'majority voted yes',
-                userId: voteData.initiator
+                userId: voteData.initiator,
+                extra: voteData.extra
             };
         }
 

--- a/views/partials/songMenu.ejs
+++ b/views/partials/songMenu.ejs
@@ -22,6 +22,7 @@
         currentMenuTrackUri = details.uri;
         dropdown.dataset.trackName = details.name;
         dropdown.dataset.trackArtist = details.artist;
+        dropdown.dataset.trackImage = details.imageUrl || '';
         dropdown.dataset.addedAt = details.addedAt || 0;
 
         // Position the dropdown
@@ -116,15 +117,14 @@
 
                 openBanReasonModal((reason) => {
                     if (userIsOwner) {
-                        // Owner bypass - start vote immediately
-                        startBanVote(currentMenuTrackUri, trackData.trackName, trackData.trackArtist, reason);
+                        startBanVote(currentMenuTrackUri, trackData.trackName, trackData.trackArtist, reason, trackData.trackImage);
                     } else {
-                        // Regular user - show payment modal first
                         pendingAction = 'Ban Vote';
                         pendingTrackUri = currentMenuTrackUri;
                         pendingTrackName = trackData.trackName || 'Unknown Track';
                         pendingTrackArtist = trackData.trackArtist || 'Unknown Artist';
                         pendingBanReason = reason;
+                        pendingTrackMeta = { image: trackData.trackImage || '' };
                         console.log('Set pendingAction to:', pendingAction);
                         console.log('Set pendingTrackUri to:', pendingTrackUri);
                         console.log('Set pendingTrackName to:', pendingTrackName);
@@ -141,7 +141,7 @@
         dropdown.style.display = 'none';
     });
 
-    function startBanVote(trackUri, trackName, trackArtist, reason) {
+    function startBanVote(trackUri, trackName, trackArtist, reason, trackImage) {
         console.log('Starting ban vote, socket:', window.banVoteSocket);
 
         const trimmedReason = (reason || 'student ban').trim();
@@ -157,7 +157,8 @@
                 trackName: trackName || 'Unknown Track',
                 trackArtist: trackArtist || 'Unknown Artist',
                 initiator: user,
-                reason: trimmedReason
+                reason: trimmedReason,
+                trackImage: trackImage || ''
             });
         } else {
             console.error('Socket connection not available');

--- a/views/partials/transactions.ejs
+++ b/views/partials/transactions.ejs
@@ -1,6 +1,6 @@
 <div class="transaction-modal-content">
     <div class="transaction-modal-header">
-        <h3>Transactions for <%= username %></h3>
+        <h3>Play History for <%= username %></h3>
         <div class="header-right">
             <div class="pagination-info">
                 <span>Page <%= pagination.currentPage %> of <%= pagination.totalPages %> (<%= pagination.totalCount %> total)</span>
@@ -14,9 +14,9 @@
                 <table class="transaction-table">
                     <thead class="sticky-header">
                         <tr>
+                            <th style="width:50px;"></th>
                             <th>Track</th>
                             <th>Artist</th>
-                            <th>Action</th>
                             <th>Cost</th>
                             <th>Time</th>
                         </tr>
@@ -24,9 +24,15 @@
                     <tbody>
                         <% transactions.forEach(function(transaction) { %>
                             <tr>
+                                <td style="width:50px;padding:4px;">
+                                    <% if (transaction.image_url) { %>
+                                        <img src="<%= transaction.image_url %>" alt="" style="width:40px;height:40px;border-radius:4px;object-fit:cover;" />
+                                    <% } else { %>
+                                        <div style="width:40px;height:40px;background:#282828;border-radius:4px;"></div>
+                                    <% } %>
+                                </td>
                                 <td><%= transaction.track_name || 'Unknown' %></td>
                                 <td><%= transaction.artist_name || 'Unknown' %></td>
-                                <td><span class="action-badge <%= transaction.action.toLowerCase() %>"><%= transaction.action %></span></td>
                                 <td><span class="cost-badge"><%= transaction.cost %> Digipogs</span></td>
                                 <td><%= transaction.formatted_time %></td>
                             </tr>
@@ -35,7 +41,7 @@
                 </table>
             </div>
         <% } else { %>
-            <p class="no-transactions">No transactions found for this user.</p>
+            <p class="no-transactions">No plays found for this user.</p>
         <% } %>
     </div>
     <div class="transaction-modal-footer">
@@ -52,4 +58,3 @@
         </div>
     </div>
 </div>
-

--- a/views/player.ejs
+++ b/views/player.ejs
@@ -333,6 +333,7 @@
             let selectedPlaylistQuote = null;
 
             // Custom playlist state
+            let pendingTrackMeta = {};
             let pendingCustomPlaylistId = null;
             let pendingCustomPlaylistName = null;
             let pendingCustomPlaylistTrackUri = null;
@@ -556,13 +557,14 @@
 
                         const userIsOwner = isOwnerClient(currentID);
                         if (userIsOwner) {
-                            startBanVote(actionTrack.uri, actionTrack.name, actionTrack.artist, 'student ban');
+                            startBanVote(actionTrack.uri, actionTrack.name, actionTrack.artist, 'student ban', actionTrack.image);
                         } else {
                             pendingAction = 'Ban Vote';
                             pendingTrackUri = actionTrack.uri;
                             pendingTrackName = actionTrack.name;
                             pendingTrackArtist = actionTrack.artist;
                             pendingBanReason = 'student ban';
+                            pendingTrackMeta = { image: actionTrack.image || '' };
                             showPayment();
                         }
                     });
@@ -636,7 +638,7 @@
                         searchSpotify();
                     }
 
-                    async function checkPaymentAndPlay(uri) {
+                    async function checkPaymentAndPlay(uri, trackMeta = {}) {
                         // Check if user is banned
                         if (userIsBanned) {
                             Notify('You have been banned from Jukebar. Contact your teacher.', 'error');
@@ -651,12 +653,13 @@
 
                         if (isOwnerClient(currentID)) {
                             const anonMode = document.getElementById('owner-anon-mode')?.checked || false;
-                            addToQueue(uri, anonMode);
+                            addToQueue(uri, anonMode, trackMeta);
                             return;
                         }
 
                         if (!hasPaid) {
                             pendingTrackUri = uri;
+                            pendingTrackMeta = trackMeta;
                             pendingAction = 'play';
                             showPayment();
                             return;
@@ -664,7 +667,7 @@
 
                         // Reset payment flag after using it
                         hasPaid = false;
-                        addToQueue(uri);
+                        addToQueue(uri, null, trackMeta);
                     }
 
                     async function checkPaymentAndSkip() {
@@ -736,14 +739,14 @@
                         }
                     }
 
-                    function addToQueue(uri, anonMode = null) {
+                    function addToQueue(uri, anonMode = null, trackMeta = {}) {
                         if (anonMode === null) {
                             anonMode = document.getElementById('anonMode')?.checked || false;
                         }
                         fetch('/addToQueue', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ uri, anonMode })
+                            body: JSON.stringify({ uri, anonMode, trackName: trackMeta.name || '', trackArtist: trackMeta.artist || '', trackImage: trackMeta.image || '' })
                         })
                             .then(response => {
                                 if (response.ok) {
@@ -770,17 +773,17 @@
                             const trackDiv = document.createElement('div');
                             trackDiv.className = 'search-result-item';
                             trackDiv.innerHTML = `
-                        <img src="${track.album.image}" alt="${track.album.name}" class="album-cover" />
+                        ${track.album.image ? `<img src="${track.album.image}" alt="${track.album.name || ''}" class="album-cover" />` : `<div class="album-cover" style="background:#282828;border-radius:4px;flex-shrink:0;"></div>`}
                         <div class="search-result-content-outer">
                             <div class="thebackgroundoftheitemsthatareinthesearchresults"></div>
                             <div class="search-result-content-pushies">
                                 <div class="search-result-title" title="${track.name}">${track.name}</div>
                                 <div class="search-result-artist" title="${track.artist}">${track.artist}</div>
                                 <div class="search-result-actions">
-                                    <button class="play-button-icon" data-uri="${track.uri}" title="Add to queue">
+                                    <button class="play-button-icon" data-uri="${track.uri}" data-name="${track.name.replace(/"/g, '&quot;')}" data-artist="${track.artist.replace(/"/g, '&quot;')}" data-image="${track.album.image || ''}" title="Add to queue">
                                         <img src="/img/play.png" alt="Play" class="play-icon">
                                     </button>
-                                    <button class="ban-button-icon" data-uri="${track.uri}" data-name="${track.name.replace(/"/g, '&quot;')}" data-artist="${track.artist.replace(/"/g, '&quot;')}" title="Vote to ban">
+                                    <button class="ban-button-icon" data-uri="${track.uri}" data-name="${track.name.replace(/"/g, '&quot;')}" data-artist="${track.artist.replace(/"/g, '&quot;')}" data-image="${track.album.image || ''}" title="Vote to ban">
                                         <img src="/img/ban.png" alt="Ban" class="ban-icon">
                                     </button>
                                 </div>
@@ -946,7 +949,7 @@
                                         }
 
                                         itemDiv.innerHTML = `
-                                        <img src="${item.album.image}" alt="${item.album.name}" class="album-cover" />
+                                        ${item.album?.image ? `<img src="${item.album.image}" alt="${item.album.name || ''}" class="album-cover" />` : `<div class="album-cover" style="background:#282828;border-radius:4px;flex-shrink:0;"></div>`}
                                         <div class="queue-item-content">
                                             <div class="queue-item-title">${item.name}</div>
                                             <div class="queue-item-artist">${item.artist}</div>
@@ -985,7 +988,7 @@
                                         const itemDiv = document.createElement('div');
                                         itemDiv.className = 'current-item';
                                         itemDiv.innerHTML = `
-                                    <img src="${item.album.image}" alt="${item.album.name}" class="album-cover" />
+                                    ${item.album?.image ? `<img src="${item.album.image}" alt="${item.album.name || ''}" class="album-cover" />` : `<div class="album-cover" style="background:#282828;border-radius:4px;flex-shrink:0;"></div>`}
                                     <div class="current-item-content">
                                         <div class="current-item-title">${item.name}</div>
                                         <div class="current-item-artist">${item.artist}</div>
@@ -1057,8 +1060,10 @@
 
                         if (action === 'play' && pendingTrackUri) {
                             const uri = pendingTrackUri;
+                            const meta = pendingTrackMeta || {};
                             pendingTrackUri = null;
-                            checkPaymentAndPlay(uri);
+                            pendingTrackMeta = {};
+                            checkPaymentAndPlay(uri, meta);
                         } else if (action === 'skip') {
                             checkPaymentAndSkip();
                         } else if (action === 'Skip Shield' && pendingTrackUri) {
@@ -1074,11 +1079,13 @@
                             const trackName = pendingTrackName || 'Unknown Track';
                             const trackArtist = pendingTrackArtist || 'Unknown Artist';
                             const reason = pendingBanReason || 'student ban';
+                            const banImage = pendingTrackMeta?.image || '';
                             pendingTrackUri = null;
                             pendingTrackName = null;
                             pendingTrackArtist = null;
                             pendingBanReason = null;
-                            startBanVote(uri, trackName, trackArtist, reason);
+                            pendingTrackMeta = {};
+                            startBanVote(uri, trackName, trackArtist, reason, banImage);
                         } else if (action === 'createPlaylist') {
                             finalizeCreatePlaylist();
                         } else if (action === 'addPlaylistSong' && pendingCustomPlaylistTrackUri) {
@@ -1267,7 +1274,7 @@
                         if (e.target.matches('.play-button, .play-button-icon') || e.target.closest('.play-button, .play-button-icon')) {
                             const button = e.target.matches('.play-button, .play-button-icon') ? e.target : e.target.closest('.play-button, .play-button-icon');
                             const uri = button.dataset.uri;
-                            if (uri) checkPaymentAndPlay(uri);
+                            if (uri) checkPaymentAndPlay(uri, { name: button.dataset.name || '', artist: button.dataset.artist || '', image: button.dataset.image || '' });
                         }
 
                         // Handle ban button
@@ -1276,6 +1283,7 @@
                             const uri = button.dataset.uri;
                             const name = button.dataset.name;
                             const artist = button.dataset.artist;
+                            const image = button.dataset.image || '';
 
                             // Check if user is banned
                             if (userIsBanned) {
@@ -1287,13 +1295,14 @@
                             const userIsOwner = isOwnerClient(currentID);
 
                             if (userIsOwner) {
-                                startBanVote(uri, name, artist, 'student ban');
+                                startBanVote(uri, name, artist, 'student ban', image);
                             } else {
                                 pendingAction = 'Ban Vote';
                                 pendingTrackUri = uri;
                                 pendingTrackName = name;
                                 pendingTrackArtist = artist;
                                 pendingBanReason = 'student ban';
+                                pendingTrackMeta = { image };
                                 showPayment();
                             }
                         }
@@ -1479,10 +1488,10 @@
                                             <div class="search-result-title" title="${track.name}">${track.name}</div>
                                             <div class="search-result-artist" title="${track.artist}">${track.artist}</div>
                                             <div class="search-result-actions">
-                                                <button class="play-button-icon" data-uri="${track.uri}" title="Add to queue">
+                                                <button class="play-button-icon" data-uri="${track.uri}" data-name="${(track.name||'').replace(/"/g, '&quot;')}" data-artist="${(track.artist||'').replace(/"/g, '&quot;')}" data-image="${track.album?.image || ''}" title="Add to queue">
                                                     <img src="/img/play.png" alt="Play" class="play-icon">
                                                 </button>
-                                                <button class="ban-button-icon" data-uri="${track.uri}" data-name="${track.name.replace(/"/g, '&quot;')}" data-artist="${track.artist.replace(/"/g, '&quot;')}" title="Vote to ban">
+                                                <button class="ban-button-icon" data-uri="${track.uri}" data-name="${(track.name||'').replace(/"/g, '&quot;')}" data-artist="${(track.artist||'').replace(/"/g, '&quot;')}" data-image="${track.album?.image || ''}" title="Vote to ban">
                                                     <img src="/img/ban.png" alt="Ban" class="ban-icon">
                                                 </button>
                                             </div>
@@ -1501,7 +1510,14 @@
                         });
 
                         socket.on('queueHistoryUpdated', () => {
-                            // Fired when the user clears their queue history
+                            const searchResults = document.getElementById('searchResults');
+                            if (searchResults) {
+                                searchResults.innerHTML = '';
+                            }
+                            loadRecentlyQueued();
+                        });
+
+                        socket.on('recentlyQueuedCleared', () => {
                             const searchResults = document.getElementById('searchResults');
                             if (searchResults) {
                                 searchResults.innerHTML = '';
@@ -1603,7 +1619,8 @@
                             uri: trackUriForActions,
                             addedAt: addedAtForActions,
                             name: track.name,
-                            artist: track.artist
+                            artist: track.artist,
+                            image: track.album?.image || ''
                         };
 
                         // Update global currentlyPlayingUri for skip functionality

--- a/views/teacher.ejs
+++ b/views/teacher.ejs
@@ -312,7 +312,7 @@
                 const reason = escapeHtml(song.reason || 'No reason given');
                 const trackName = escapeHtml(song.track_name || 'Unknown Track');
                 const artistName = escapeHtml(song.artist_name || 'Unknown Artist');
-                const albumImage = escapeHtml(song.album_image || '/img/placeholder.png');
+                const albumImage = song.album_image || '';
                 const when = song.timestamp ? new Date(song.timestamp).toLocaleString() : 'Unknown time';
                 const whenEscaped = escapeHtml(when);
                 const trackNameAttr = escapeHtml(song.track_name || '');
@@ -320,7 +320,7 @@
 
                 return `
                     <div class="search-result-item">
-                        <img src="${albumImage}" alt="${trackName}" class="album-cover" />
+                        ${albumImage ? `<img src="${escapeHtml(albumImage)}" alt="${trackName}" class="album-cover" />` : `<div class="album-cover" style="background:#282828;border-radius:4px;flex-shrink:0;"></div>`}
                         <div class="search-result-content">
                             <div class="search-result-title">${trackName}</div>
                             <div class="search-result-artist">${artistName}</div>
@@ -381,6 +381,13 @@
 
                 meta.appendChild(name);
                 meta.appendChild(details);
+
+                if (playlist.canAccessTracks === false) {
+                    const warn = document.createElement('div');
+                    warn.style.cssText = 'color:#ff9800;font-size:0.7em;margin-top:2px;';
+                    warn.textContent = 'Not owned — students cannot queue this playlist';
+                    meta.appendChild(warn);
+                }
 
                 const actionBtn = document.createElement('button');
                 let isAllowed = !!playlist.isAllowed;
@@ -651,7 +658,7 @@
 
                     // Constructs inner HTML
                     playDiv.innerHTML = `
-                        <img src="${play.albumImage || '/img/placeholder.png'}" alt="${play.track_name}" class="album-cover" style="width: 60px; height: 60px; border-radius: 8px; margin-right: 16px; object-fit: cover;" />
+                        ${play.albumImage ? `<img src="${play.albumImage}" alt="${play.track_name}" class="album-cover" style="width: 60px; height: 60px; border-radius: 8px; margin-right: 16px; object-fit: cover;" />` : `<div class="album-cover" style="width:60px;height:60px;background:#282828;border-radius:8px;margin-right:16px;flex-shrink:0;"></div>`}
                         <div style="flex: 1; min-width: 0;">
                             <div style="font-weight: 600; font-size: 1rem; margin: 0 0 4px 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${play.track_name}</div>
                             <div style="color: rgba(255, 255, 255, 0.7); font-size: 0.9rem; margin: 0;">${play.artist_name}</div>
@@ -744,7 +751,7 @@
                                 <div class="search-result-title">${track.name}</div>
                                 <div class="search-result-artist">${track.artist}</div>
                             </div>
-                            <button class="${isBanned ? 'unban-button' : 'ban-button'}" data-uri="${track.uri}" data-name="${track.name}" data-artist="${track.artist}" title="${isBanned ? 'Unban this track' : 'Ban this track'}">${isBanned ? 'Unban' : 'Ban'}</button>
+                            <button class="${isBanned ? 'unban-button' : 'ban-button'}" data-uri="${track.uri}" data-name="${track.name}" data-artist="${track.artist}" data-image="${track.album.image || ''}" title="${isBanned ? 'Unban this track' : 'Ban this track'}">${isBanned ? 'Unban' : 'Ban'}</button>
                             `;
                     resultsDiv.appendChild(trackDiv);
                 });
@@ -856,6 +863,7 @@
         const name = btn.dataset.name;
         const artist = btn.dataset.artist;
         const uri = btn.dataset.uri;
+        const image = btn.dataset.image || '';
         if (!name || !artist) return;
 
         try {
@@ -865,7 +873,7 @@
                         const res = await fetch('/banTrack', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ name, artist, reason, uri })
+                            body: JSON.stringify({ name, artist, reason, uri, image })
                         });
                         const data = await res.json();
                         if (res.ok && data.ok) {


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to Spotify playlist handling, error reporting, and track metadata management, especially in light of the February 2026 Spotify API changes. The most significant updates include enhanced error handling for playlist fetches, support for storing and returning track images, and improvements to the recently queued tracks logic.

**Spotify API changes and error handling:**
- Updated all playlist track fetches to use the new `/items` endpoint and added robust error handling for cases such as 403 (forbidden) and 429 (rate limit), including user-facing error messages and logging. Functions now return both tracks and error information, and endpoints respond accordingly if a fetch fails. [[1]](diffhunk://#diff-e4dc103ead17c9754942501fbaaeaa02379f49ca11eb54b84ad7e1e3da927678L52-R72) [[2]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fR346-R376) [[3]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fL405-R459) [[4]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fL438-R480) [[5]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fR850-R854) [[6]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fR937-R941)

**Track image support:**
- Extended the schema and logic for banned songs and transaction logging to include a `trackImage`/`image_url` field, ensuring that track images are stored when banning or queuing tracks and are returned in recently queued track results. [[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL164-R167) [[2]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL245-R248) [[3]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL264-R265) [[4]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL307-R309) [[5]](diffhunk://#diff-4064dfc0252d73f8e46041c2b80e79da444d3e8eb8413fed6bc0d05ba1359723L3-R7) [[6]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fL606-R650) [[7]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fL935-R1017) [[8]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fR1035-R1040) [[9]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fL1073-R1157)

**Recently queued tracks and clearing logic:**
- Improved the logic for clearing the recently queued list by updating a timestamp in the `users` table instead of deleting transaction records. Added a new teacher-only endpoint to clear recently queued tracks for all users and emit a notification. [[1]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fL624-R668) [[2]](diffhunk://#diff-f91db24294b7b01befa4180cd547ad6c5d316b4eb3aba8a752ebff892df8f80fR687-R716)

**Playlist access and metadata:**
- Updated playlist metadata returned by the API to include whether the current user can access tracks (i.e., is owner or collaborator), in line with new Spotify permissions requirements.

**Spotify error message extraction:**
- Enhanced the Spotify API error handler to extract and log more meaningful error messages, even when the error object is poorly structured.